### PR TITLE
Fixed setup of GA tags when favicon is not present

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -20,7 +20,8 @@
 
 {{ if .Site.Params.favicon }}
 <link rel="shortcut icon" href="/{{ .Site.Params.favicon }}" type="image/png" />
+{{ end }}
 
+{{ if .Site.GoogleAnalytics }}
 {{ template "_internal/google_analytics.html" . }}
-
 {{ end }}


### PR DESCRIPTION
Fixed as suggest in #6 